### PR TITLE
Deploy to docker desktop

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -36,8 +36,8 @@ services:
       - GOOGLE_CLIENT_SECRET=${GOOGLE_CLIENT_SECRET}
       - JWT_SECRET=${JWT_SECRET}
       - JWT_REFRESH_SECRET=${JWT_REFRESH_SECRET}
-      - CLIENT_URL=http://p-inverntory.mfu.ac.th
-      - SERVER_URL=http://p-inverntory.mfu.ac.th
+      - CLIENT_URL=http://p-inventory.mfu.ac.th
+      - SERVER_URL=http://p-inventory.mfu.ac.th
     volumes:
       - ./backend/uploads:/app/uploads
     depends_on:


### PR DESCRIPTION
Corrects a typo in `docker-compose.yml` to use the correct domain `p-inventory.mfu.ac.th` for `CLIENT_URL` and `SERVER_URL`.

---
<a href="https://cursor.com/background-agent?bcId=bc-eb7ca161-4616-409a-8d23-cf01bbf4a702">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-eb7ca161-4616-409a-8d23-cf01bbf4a702">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

